### PR TITLE
fix: cargo version and ic-wasm in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+scripts/docker_build.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,12 @@ jobs:
     - name: Build
       run: |
         ./scripts/docker_build.sh
-    - name: gzip artifact
+    - name: hash artifact
       run: |
         sha256sum subnet_rental_canister.wasm > src_sha256.txt
-        gzip subnet_rental_canister.wasm
-        sha256sum subnet_rental_canister.wasm.gz >> src_sha256.txt
     - name: upload artifacts to release page
       uses: softprops/action-gh-release@master
       with:
         files: |
-          subnet_rental_canister.wasm.gz
+          subnet_rental_canister.wasm
           src_sha256.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 ubuntu:22.04
 
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
-ENV RUST_VERSION=1.74.0
+ENV RUST_VERSION=1.77.1
 
 # Set the timezone to UTC
 ENV TZ=UTC
@@ -17,8 +17,7 @@ ENV PATH=/opt/cargo/bin:${PATH}
 RUN curl --fail https://sh.rustup.rs -sSf \
     | sh -s -- -y --default-toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu --no-modify-path && \
     rustup default ${RUST_VERSION}-x86_64-unknown-linux-gnu && \
-    rustup target add wasm32-unknown-unknown &&\
-    cargo install ic-wasm --version 0.7.0
+    rustup target add wasm32-unknown-unknown
 
 COPY . /subnet-rental-canister
 WORKDIR /subnet-rental-canister

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /subnet-rental-canister
 RUN ./scripts/build.sh
 
 # Shrink the canister
-RUN ic-wasm subnet_rental_canister.wasm -o subnet_rental_canister.wasm shrink
+RUN ./ic-wasm subnet_rental_canister.wasm -o subnet_rental_canister.wasm shrink

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Make sure we always run from the root
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPTS_DIR/.."
@@ -19,13 +21,24 @@ fi
 curl -sL "${URL}" -o ic-wasm || exit 1
 chmod +x ic-wasm
 
-# auto-create the candid interface
-cargo install candid-extractor --version 0.1.3
-candid-extractor subnet_rental_canister.wasm > src/subnet_rental_canister/subnet_rental_canister.did
+if [[ "$OSTYPE" == "linux"* || "$RUNNER_OS" == "Linux" ]]; then
+  URL="https://github.com/dfinity/cdk-rs/releases/download/candid-extractor-v0.1.3/candid-extractor-x86_64-unknown-linux-gnu.tar.gz"
+elif [[ "$OSTYPE" == "darwin"* || "$RUNNER_OS" == "macOS" ]]; then
+  URL="https://github.com/dfinity/cdk-rs/releases/download/candid-extractor-v0.1.3/candid-extractor-x86_64-apple-darwin.tar.gz"
+else
+  echo "OS not supported: ${OSTYPE:-$RUNNER_OS}"
+  exit 1
+fi
+curl -sL "${URL}" -o candid-extractor.tar.gz || exit 1
+tar -xzf candid-extractor.tar.gz
+chmod +x candid-extractor
 
 # Build canister
 export RUSTFLAGS="--remap-path-prefix $(readlink -f $(dirname ${0}))=/build --remap-path-prefix ${CARGO_HOME}=/cargo"
 cargo rustc -p subnet_rental_canister --crate-type=cdylib --locked --target wasm32-unknown-unknown --release
+
+# auto-create the candid interface
+./candid-extractor ./target/wasm32-unknown-unknown/release/subnet_rental_canister.wasm > src/subnet_rental_canister/subnet_rental_canister.did
 
 # include the candid interface in the canister WASM
 ./ic-wasm ./target/wasm32-unknown-unknown/release/subnet_rental_canister.wasm -o ./target/wasm32-unknown-unknown/release/subnet_rental_canister.wasm metadata candid:service -f src/subnet_rental_canister/subnet_rental_canister.did -v public

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+
 # Make sure we always run from the root
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPTS_DIR/.."

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -7,7 +7,7 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPTS_DIR/.."
 
 # Build the Docker image and run it to build the canister
-docker build -t subnet-rental-canister .
-CONTAINER_ID=$(docker run --platform="linux/amd64" -d subnet-rental-canister)
+docker build -t localhost/subnet-rental-canister .
+CONTAINER_ID=$(docker run --platform="linux/amd64" -d localhost/subnet-rental-canister)
 docker cp $CONTAINER_ID:/subnet-rental-canister/target/wasm32-unknown-unknown/release/subnet_rental_canister.wasm . 
 docker rm -f $CONTAINER_ID


### PR DESCRIPTION
This PR fixes:
- the cargo version in the Dockerfile
- removes ic-wasm from Dockerfile (as it is downloaded by build.sh anyway)
- downloads candid-extractor instead of building it from sources
- only runs candid-extractor once the canister WASM is built
- adds a `.dockerignore` (so that `Dockerfile` and `docker_build.sh` changes do not invalidate the docker cache which helps when debugging)
- adds `set -euo pipefail` to `build.sh`
- prefixes the Docker image tag with `localhost/`
- initializes `CARGO_HOME` in `scripts/build.sh`
- do not gzip artifacts