### PR TITLE
chore: make time units explicit in field names

### DIFF
--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -88,9 +88,9 @@ async fn locking() {
             initial_proposal_id,
             creation_time_nanos,
             rental_condition_id,
-            last_locking_time,
+            last_locking_time_nanos,
         } = rental_request;
-        if (now - last_locking_time) / BILLION / 60 / 60 / 24 >= 30 {
+        if (now - last_locking_time_nanos) / BILLION / 60 / 60 / 24 >= 30 {
             let lock_amount_icp = Tokens::from_e8s(initial_cost_icp.e8s() / 10);
             // Only try to lock if we haven't already locked 100% or more.
             // Use multiplication result to account for rounding errors.
@@ -140,7 +140,7 @@ async fn locking() {
                 creation_time_nanos,
                 rental_condition_id,
                 // we risk not accounting for a few days in case this function does not run as scheduled
-                last_locking_time: now,
+                last_locking_time_nanos: now,
             };
             update_rental_request(user, move |_| new_rental_request).unwrap();
         }
@@ -485,7 +485,7 @@ pub async fn refund() -> Result<u64, String> {
                 initial_proposal_id,
                 creation_time_nanos: _,
                 rental_condition_id: _,
-                last_locking_time: _,
+                last_locking_time_nanos: _,
             },
         ) => {
             println!("Refund requested for user principal {}", &caller);

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -86,7 +86,7 @@ async fn locking() {
             locked_amount_icp,
             locked_amount_cycles,
             initial_proposal_id,
-            creation_date,
+            creation_time_nanos,
             rental_condition_id,
             last_locking_time,
         } = rental_request;
@@ -137,7 +137,7 @@ async fn locking() {
                 locked_amount_icp,
                 locked_amount_cycles,
                 initial_proposal_id,
-                creation_date,
+                creation_time_nanos,
                 rental_condition_id,
                 // we risk not accounting for a few days in case this function does not run as scheduled
                 last_locking_time: now,
@@ -483,7 +483,7 @@ pub async fn refund() -> Result<u64, String> {
                 locked_amount_icp: _,
                 locked_amount_cycles,
                 initial_proposal_id,
-                creation_date: _,
+                creation_time_nanos: _,
                 rental_condition_id: _,
                 last_locking_time: _,
             },

--- a/src/subnet_rental_canister/src/canister_state.rs
+++ b/src/subnet_rental_canister/src/canister_state.rs
@@ -276,7 +276,7 @@ pub fn create_rental_agreement(
         subnet_creation_proposal_id,
         rental_condition_id,
         creation_time_nanos: now,
-        covered_until: now + initial_rental_period_nanos,
+        covered_until_nanos: now + initial_rental_period_nanos,
         cycles_balance,
         last_burned: now,
     };

--- a/src/subnet_rental_canister/src/canister_state.rs
+++ b/src/subnet_rental_canister/src/canister_state.rs
@@ -215,7 +215,7 @@ pub fn create_rental_request(
     locked_amount_cycles: u128,
     initial_proposal_id: u64,
     rental_condition_id: RentalConditionId,
-    last_locking_time: u64,
+    last_locking_time_nanos: u64,
 ) -> Result<(), String> {
     let now = ic_cdk::api::time();
     let rental_request = RentalRequest {
@@ -227,7 +227,7 @@ pub fn create_rental_request(
         initial_proposal_id,
         creation_time_nanos: now,
         rental_condition_id,
-        last_locking_time,
+        last_locking_time_nanos,
     };
     RENTAL_REQUESTS.with_borrow_mut(|requests| {
         if requests.contains_key(&user) {
@@ -324,7 +324,7 @@ mod canister_state_test {
                         initial_proposal_id: 99,
                         creation_time_nanos: date,
                         rental_condition_id: RentalConditionId::App13CH,
-                        last_locking_time: 99,
+                        last_locking_time_nanos: 99,
                     },
                 },
             )

--- a/src/subnet_rental_canister/src/canister_state.rs
+++ b/src/subnet_rental_canister/src/canister_state.rs
@@ -204,7 +204,7 @@ pub fn get_history_page(
     (page, low_seq)
 }
 
-/// Create a RentalRequest with the current time as create_date, insert into canister state
+/// Create a RentalRequest with the current time as creation_time_nanos, insert into canister state
 /// and persist the corresponding event.
 #[allow(clippy::too_many_arguments)]
 pub fn create_rental_request(
@@ -311,9 +311,9 @@ mod canister_state_test {
 
     #[test]
     fn test_history_pagination() {
-        fn make_event(date: u64) -> Event {
+        fn make_event(time_nanos: u64) -> Event {
             Event::_mk_event(
-                date,
+                time_nanos,
                 EventType::RentalRequestCreated {
                     rental_request: RentalRequest {
                         user: Principal::anonymous(),
@@ -322,7 +322,7 @@ mod canister_state_test {
                         locked_amount_icp: Tokens::from_e8s(10),
                         locked_amount_cycles: 99,
                         initial_proposal_id: 99,
-                        creation_time_nanos: date,
+                        creation_time_nanos: time_nanos,
                         rental_condition_id: RentalConditionId::App13CH,
                         last_locking_time_nanos: 99,
                     },
@@ -335,15 +335,15 @@ mod canister_state_test {
         persist_event(make_event(4), None);
         persist_event(make_event(5), None);
         let (events, oldest) = get_history_page(None, None, 2);
-        assert_eq!(events[0].date(), 4);
-        assert_eq!(events[1].date(), 5);
+        assert_eq!(events[0].time_nanos(), 4);
+        assert_eq!(events[1].time_nanos(), 5);
         assert_eq!(events.len(), 2);
         let (events, oldest) = get_history_page(None, Some(oldest), 2);
-        assert_eq!(events[0].date(), 2);
-        assert_eq!(events[1].date(), 3);
+        assert_eq!(events[0].time_nanos(), 2);
+        assert_eq!(events[1].time_nanos(), 3);
         assert_eq!(events.len(), 2);
         let (events, oldest) = get_history_page(None, Some(oldest), 2);
-        assert_eq!(events[0].date(), 1);
+        assert_eq!(events[0].time_nanos(), 1);
         assert_eq!(events.len(), 1);
         let (events, oldest) = get_history_page(None, Some(oldest), 2);
         assert!(events.is_empty());

--- a/src/subnet_rental_canister/src/canister_state.rs
+++ b/src/subnet_rental_canister/src/canister_state.rs
@@ -225,7 +225,7 @@ pub fn create_rental_request(
         locked_amount_icp,
         locked_amount_cycles,
         initial_proposal_id,
-        creation_date: now,
+        creation_time_nanos: now,
         rental_condition_id,
         last_locking_time,
     };
@@ -251,7 +251,7 @@ pub fn take_rental_request(user: Principal) -> Option<RentalRequest> {
     RENTAL_REQUESTS.with_borrow_mut(|requests| requests.remove(&user))
 }
 
-/// Create a RentalAgreement with the current time as creation_date, insert into canister state  
+/// Create a RentalAgreement with the current time as creation_time_nanos, insert into canister state  
 /// and create the corresponding event.
 #[allow(clippy::too_many_arguments)]
 pub fn create_rental_agreement(
@@ -275,7 +275,7 @@ pub fn create_rental_agreement(
         initial_proposal_id,
         subnet_creation_proposal_id,
         rental_condition_id,
-        creation_date: now,
+        creation_time_nanos: now,
         covered_until: now + initial_rental_period_nanos,
         cycles_balance,
         last_burned: now,
@@ -322,7 +322,7 @@ mod canister_state_test {
                         locked_amount_icp: Tokens::from_e8s(10),
                         locked_amount_cycles: 99,
                         initial_proposal_id: 99,
-                        creation_date: date,
+                        creation_time_nanos: date,
                         rental_condition_id: RentalConditionId::App13CH,
                         last_locking_time: 99,
                     },

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 /// so that system time is captured automatically.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, CandidType, Deserialize)]
 pub struct Event {
-    date: u64,
+    time_nanos: u64,
     event: EventType,
 }
 
@@ -32,13 +32,13 @@ impl Event {
         self.event.clone()
     }
 
-    pub fn date(&self) -> u64 {
-        self.date
+    pub fn time_nanos(&self) -> u64 {
+        self.time_nanos
     }
 
     #[cfg(test)]
-    pub fn _mk_event(date: u64, event: EventType) -> Self {
-        Self { date, event }
+    pub fn _mk_event(time_nanos: u64, event: EventType) -> Self {
+        Self { time_nanos, event }
     }
 }
 
@@ -46,7 +46,7 @@ impl From<EventType> for Event {
     fn from(value: EventType) -> Self {
         Event {
             event: value,
-            date: ic_cdk::api::time(),
+            time_nanos: ic_cdk::api::time(),
         }
     }
 }

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -95,7 +95,7 @@ pub enum EventType {
     PaymentSuccess {
         amount: Tokens,
         cycles: u128,
-        covered_until: u64,
+        covered_until_nanos: u64,
     },
     PaymentFailure {
         reason: String,

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -118,7 +118,7 @@ pub struct RentalAgreement {
     pub creation_time_nanos: u64,
     // ===== Mutable data =====
     /// The time in nanos since epoch until which the rental agreement is paid for.
-    pub covered_until: u64,
+    pub covered_until_nanos: u64,
     /// This subnet's share of cycles among the SRC's cycles.
     /// Increased by the locking mechanism, monthly.
     /// Increased by the payment process (via timer).

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -81,7 +81,7 @@ pub struct RentalRequest {
     /// creation proposal. When this is found on the governance
     /// canister, polling can stop.
     pub initial_proposal_id: u64,
-    /// Rental request creation date in nanoseconds since epoch.
+    /// Rental request creation time in nanoseconds since epoch.
     pub creation_time_nanos: u64,
     /// A key into the global RENTAL_CONDITIONS HashMap.
     pub rental_condition_id: RentalConditionId,
@@ -114,10 +114,10 @@ pub struct RentalAgreement {
     pub subnet_creation_proposal_id: Option<u64>,
     /// A key into the global RENTAL_CONDITIONS HashMap.
     pub rental_condition_id: RentalConditionId,
-    /// Rental agreement creation date in nanoseconds since epoch.
+    /// Rental agreement creation time in nanoseconds since epoch.
     pub creation_time_nanos: u64,
     // ===== Mutable data =====
-    /// The date in nanos since epoch until which the rental agreement is paid for.
+    /// The time in nanos since epoch until which the rental agreement is paid for.
     pub covered_until: u64,
     /// This subnet's share of cycles among the SRC's cycles.
     /// Increased by the locking mechanism, monthly.

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -82,7 +82,7 @@ pub struct RentalRequest {
     /// canister, polling can stop.
     pub initial_proposal_id: u64,
     /// Rental request creation date in nanoseconds since epoch.
-    pub creation_date: u64,
+    pub creation_time_nanos: u64,
     /// A key into the global RENTAL_CONDITIONS HashMap.
     pub rental_condition_id: RentalConditionId,
     /// ===== Data for the ICP-locking timer. =====
@@ -115,7 +115,7 @@ pub struct RentalAgreement {
     /// A key into the global RENTAL_CONDITIONS HashMap.
     pub rental_condition_id: RentalConditionId,
     /// Rental agreement creation date in nanoseconds since epoch.
-    pub creation_date: u64,
+    pub creation_time_nanos: u64,
     // ===== Mutable data =====
     /// The date in nanos since epoch until which the rental agreement is paid for.
     pub covered_until: u64,

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -88,7 +88,7 @@ pub struct RentalRequest {
     /// ===== Data for the ICP-locking timer. =====
     /// The last time ICP were successfully locked. If this is
     /// 30d in the past, a new locking event should trigger.
-    pub last_locking_time: u64,
+    pub last_locking_time_nanos: u64,
 }
 
 impl Storable for RentalRequest {

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -250,7 +250,7 @@ fn test_initial_proposal() {
         locked_amount_icp: _,
         locked_amount_cycles: _,
         initial_proposal_id: _,
-        creation_date: _,
+        creation_time_nanos: _,
         rental_condition_id,
         last_locking_time: _,
     } = rental_requests[0];

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -252,7 +252,7 @@ fn test_initial_proposal() {
         initial_proposal_id: _,
         creation_time_nanos: _,
         rental_condition_id,
-        last_locking_time: _,
+        last_locking_time_nanos: _,
     } = rental_requests[0];
     assert_eq!(user, user_principal);
     assert_eq!(rental_condition_id, RentalConditionId::App13CH);
@@ -444,7 +444,9 @@ fn test_locking() {
         updated_rental_request.refundable_icp,
         initial_amount_icp - lock_amount_icp - lock_amount_icp
     );
-    assert!(rental_request.last_locking_time < updated_rental_request.last_locking_time);
+    assert!(
+        rental_request.last_locking_time_nanos < updated_rental_request.last_locking_time_nanos
+    );
     // repeat 9 times (once more than necessary to lock everything; should silently succeed)
     for _ in 0..9 {
         pic.advance_time(Duration::from_secs(60 * 60 * 24 * 30 + 1));


### PR DESCRIPTION
This MR renames
- the field `creation_date` to `creation_time_nanos`
- the field `last_locking_time` to `last_locking_time_nanos`
- the field `date` to `time_nanos`
- the field `covered_until` to `covered_until_nanos`

to make the time units explicit. This makes it less likely to run into issues such as fixed by https://github.com/dfinity/subnet-rental-canister/pull/59 in the future.