### PR TITLE
fix: amount of ICP transferred to CMC

### DIFF
--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -490,20 +490,18 @@ pub async fn refund() -> Result<u64, String> {
         ) => {
             println!("Refund requested for user principal {}", &caller);
             // Refund the remaining ICP on the SRC/user subaccount to the user.
-            let res = refund_user(user, refundable_icp - DEFAULT_FEE, initial_proposal_id).await;
+            let res = refund_user(user, refundable_icp, initial_proposal_id).await;
             let Ok(block_id) = res else {
                 return Err(format!(
                     "Failed to refund {} ICP to {}: {:?}",
-                    refundable_icp - DEFAULT_FEE,
+                    refundable_icp,
                     user,
                     res.unwrap_err()
                 ));
             };
             println!(
                 "SRC refunded {} ICP to {}, block_id: {}",
-                refundable_icp - DEFAULT_FEE,
-                user,
-                block_id
+                refundable_icp, user, block_id
             );
             ic_cdk::api::cycles_burn(locked_amount_cycles);
             println!(

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -490,18 +490,20 @@ pub async fn refund() -> Result<u64, String> {
         ) => {
             println!("Refund requested for user principal {}", &caller);
             // Refund the remaining ICP on the SRC/user subaccount to the user.
-            let res = refund_user(user, refundable_icp, initial_proposal_id).await;
+            let res = refund_user(user, refundable_icp - DEFAULT_FEE, initial_proposal_id).await;
             let Ok(block_id) = res else {
                 return Err(format!(
                     "Failed to refund {} ICP to {}: {:?}",
-                    refundable_icp,
+                    refundable_icp - DEFAULT_FEE,
                     user,
                     res.unwrap_err()
                 ));
             };
             println!(
                 "SRC refunded {} ICP to {}, block_id: {}",
-                refundable_icp, user, block_id
+                refundable_icp - DEFAULT_FEE,
+                user,
+                block_id
             );
             ic_cdk::api::cycles_burn(locked_amount_cycles);
             println!(

--- a/src/subnet_rental_canister/src/external_calls.rs
+++ b/src/subnet_rental_canister/src/external_calls.rs
@@ -152,8 +152,8 @@ pub async fn convert_icp_to_cycles(
     amount: Tokens,
     source: Subaccount,
 ) -> Result<u128, ExecuteProposalError> {
-    // Transfer the ICP from the SRC to the CMC. The second fee is for the notify top-up.
-    let transfer_to_cmc_result = transfer_to_cmc(amount - DEFAULT_FEE - DEFAULT_FEE, source).await;
+    // Transfer the ICP from the SRC to the CMC.
+    let transfer_to_cmc_result = transfer_to_cmc(amount - DEFAULT_FEE, source).await;
     let Ok(block_index) = transfer_to_cmc_result else {
         let e = transfer_to_cmc_result.unwrap_err();
         println!("Transfer from SRC to CMC failed: {:?}", e);

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -315,7 +315,11 @@ fn test_initial_proposal() {
 
     // check that transfer has succeeded
     let balance_after = check_balance(&pic, user_principal, DEFAULT_SUBACCOUNT);
-    assert_eq!(balance_after - balance_before, refundable_icp - DEFAULT_FEE);
+    assert_eq!(balance_after - balance_before, refundable_icp);
+
+    // check that no funds are left on SRC subaccount
+    let src_balance = check_balance(&pic, src_principal, Subaccount::from(user_principal));
+    assert_eq!(src_balance, Tokens::from_e8s(0));
 
     // afterwards there should be no more rental requests remaining
     let rental_requests =

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -315,7 +315,7 @@ fn test_initial_proposal() {
 
     // check that transfer has succeeded
     let balance_after = check_balance(&pic, user_principal, DEFAULT_SUBACCOUNT);
-    assert_eq!(balance_after - balance_before, refundable_icp);
+    assert_eq!(balance_after - balance_before, refundable_icp - DEFAULT_FEE);
 
     // check that no funds are left on SRC subaccount
     let src_balance = check_balance(&pic, src_principal, Subaccount::from(user_principal));


### PR DESCRIPTION
This MR fixes the amount of ICP transferred to CMC for minting cycles: there's no need to deduct the transfer fee twice and by doing so there are currently 0.0001 ICP left (which could be confusing) if a rental request is cancelled by requesting a refund.