### PR TITLE
fix: Bump ic-cdk version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8859bc2b863a77750acf199e1fb7e3fc403e1b475855ba13f59cb4e4036d238"
+checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
 dependencies = [
  "candid",
  "ic-cdk-macros",

--- a/src/subnet_rental_canister/Cargo.toml
+++ b/src/subnet_rental_canister/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 candid = "0.10.2"
 hex = "0.4.3"
-ic-cdk = "0.13.1"
+ic-cdk = "0.13.5"
 ic-cdk-timers = "0.7.0"
 ic-ledger-types = "0.10.0"
 ic-stable-structures = "0.6.4"


### PR DESCRIPTION
This patches a problem in the ic-cdk dependency. 