### PR TITLE
feat: Add endpoint to allow updating super users of rented subnets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "slotmap",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.40.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e7706e55836e8104c98149ec0796d20d5213fef972ac01b544657d410f1883"
+checksum = "4a775244756a5d97ff19b08071a946a4b4896904e35deb036bf215e80f2e703d"
 dependencies = [
  "candid",
  "hex",
@@ -784,7 +784,7 @@ dependencies = [
  "serde_cbor",
  "serde_repr",
  "sha2",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1278,9 +1278,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pocket-ic"
-version = "11.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67394a1de5e9bd67e92eef90c9034fbd28f26cfcb64854f187f3979191d6380c"
+checksum = "e30621a12b204880522340df8327930d1b7fdefd784c9fc6093b311440fa0506"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -1294,7 +1294,6 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2",
@@ -1302,7 +1301,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -1377,7 +1376,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1398,7 +1397,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2030,11 +2029,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2050,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/subnet_rental_canister/Cargo.toml
+++ b/src/subnet_rental_canister/Cargo.toml
@@ -22,4 +22,4 @@ serde_bytes = "0.11.17"
 sha2 = "0.10.9"
 
 [dev-dependencies]
-pocket-ic = "11.0.0"
+pocket-ic = "13.0.0"

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -10,9 +10,11 @@ use crate::{
         refund_user, set_authorized_subnetwork_list,
     },
     history::EventType,
-    CreateRentalAgreementPayload, EventPage, ExecuteProposalError, PriceCalculationData,
-    RentalAgreement, RentalAgreementStatus, RentalConditionId, RentalConditions, RentalRequest,
-    SubnetRentalProposalPayload, TopUpSummary, BILLION, TRILLION,
+    CreateRentalAgreementPayload, EventPage, ExecuteProposalError, OperationType,
+    PriceCalculationData, RentalAgreement, RentalAgreementStatus, RentalConditionId,
+    RentalConditions, RentalRequest, SubnetRentalProposalPayload, TopUpSummary,
+    UpdateSubnetAdminsError, UpdateSubnetAdminsPayload, UpdateSubnetAdminsResult, BILLION,
+    TRILLION,
 };
 use candid::Principal;
 use ic_cdk::{
@@ -824,6 +826,63 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
     })
 }
 
+/// Callable by any principal that is renting a subnet to update the list of subnet admins for this subnet.
+#[update]
+pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateSubnetAdminsResult {
+    let subnet_id = payload.subnet_id;
+    // Make sure that there are no other concurrent operations on the subnet
+    // that could change its agreement status (e.g. if the subnet is not rented
+    // anymore, there should not be an in-flight request to change subnet admins).
+
+    // Additionally, this protects against multiple in-flight requests to update
+    // subnet admins -- it would probably be ok as the update happens in an
+    // idempotent way at the moment on the registry's side but there is no strong
+    // guarantee that this won't change in the future.
+    let Ok(_guard_res) = CallerGuard::new(subnet_id, "agreement") else {
+        println!(
+            "Busy processing another update_subnet_admins request for subnet {}",
+            payload.subnet_id
+        );
+        return UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::ConcurrentChange(
+            candid::Reserved,
+        )));
+    };
+
+    // Caller must be renting the subnet they are trying to set admins for.
+    if let Err(e) = verify_caller_is_renting_subnet(subnet_id) {
+        return UpdateSubnetAdminsResult::Err(Some(e));
+    }
+
+    let provided_principals_count = match &payload.operation_type {
+        None => {
+            return UpdateSubnetAdminsResult::Err(Some(
+                UpdateSubnetAdminsError::UnknownOperationType(candid::Reserved),
+            ));
+        }
+        Some(OperationType::Add(provided_principals))
+        | Some(OperationType::Remove(provided_principals)) => {
+            let provided_principals_count = provided_principals.get().len() as u64;
+            if provided_principals_count == 0 {
+                return UpdateSubnetAdminsResult::Err(Some(
+                    UpdateSubnetAdminsError::PrincipalListEmpty(candid::Reserved),
+                ));
+            }
+            provided_principals_count
+        }
+        Some(OperationType::Clear(_)) => 0,
+    };
+
+    let res = crate::external_calls::update_subnet_admins(payload.into()).await;
+    match res {
+        Ok(()) => UpdateSubnetAdminsResult::Ok(candid::Reserved),
+        Err(e) => UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::from((
+            e,
+            subnet_id,
+            provided_principals_count,
+        )))),
+    }
+}
+
 // ============================================================================
 // Misc
 
@@ -831,6 +890,22 @@ fn verify_caller_is_governance() -> Result<(), ExecuteProposalError> {
     if msg_caller() != MAINNET_GOVERNANCE_CANISTER_ID {
         println!("Caller is not the governance canister");
         return Err(ExecuteProposalError::UnauthorizedCaller);
+    }
+    Ok(())
+}
+
+fn verify_caller_is_renting_subnet(subnet_id: Principal) -> Result<(), UpdateSubnetAdminsError> {
+    let caller = msg_caller();
+    let is_renting = iter_rental_agreements()
+        .iter()
+        .any(|(_, v)| v.user == caller && v.subnet_id == subnet_id);
+    if !is_renting {
+        println!(
+            "Unauthorized caller {caller} attempted to update subnet admins for subnet {subnet_id}",
+        );
+        return Err(UpdateSubnetAdminsError::CallerNotRentingSubnet(
+            candid::Reserved,
+        ));
     }
     Ok(())
 }

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -830,6 +830,12 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
 #[update]
 pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateSubnetAdminsResult {
     let subnet_id = payload.subnet_id;
+
+    // Caller must be renting the subnet they are trying to set admins for.
+    if let Err(e) = verify_caller_is_renting_subnet(subnet_id) {
+        return UpdateSubnetAdminsResult::Err(Some(e));
+    }
+
     // Make sure that there are no other concurrent operations on the subnet
     // that could change its agreement status (e.g. if the subnet is not rented
     // anymore, there should not be an in-flight request to change subnet admins).
@@ -847,11 +853,6 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
             candid::Reserved,
         )));
     };
-
-    // Caller must be renting the subnet they are trying to set admins for.
-    if let Err(e) = verify_caller_is_renting_subnet(subnet_id) {
-        return UpdateSubnetAdminsResult::Err(Some(e));
-    }
 
     let provided_principals_count = match &payload.operation_type {
         None => {

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -854,7 +854,7 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
         )));
     };
 
-    let provided_principals_count = match &payload.operation_type {
+    match &payload.operation_type {
         None => {
             return UpdateSubnetAdminsResult::Err(Some(
                 UpdateSubnetAdminsError::UnknownOperationType(candid::Reserved),
@@ -862,25 +862,19 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
         }
         Some(OperationType::Add(provided_principals))
         | Some(OperationType::Remove(provided_principals)) => {
-            let provided_principals_count = provided_principals.get().len() as u64;
-            if provided_principals_count == 0 {
+            if provided_principals.get().is_empty() {
                 return UpdateSubnetAdminsResult::Err(Some(
                     UpdateSubnetAdminsError::PrincipalListEmpty(candid::Reserved),
                 ));
             }
-            provided_principals_count
         }
-        Some(OperationType::Clear(_)) => 0,
+        Some(OperationType::Clear(_)) => {}
     };
 
     let res = crate::external_calls::update_subnet_admins(payload.into()).await;
     match res {
         Ok(()) => UpdateSubnetAdminsResult::Ok(candid::Reserved),
-        Err(e) => UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::from((
-            e,
-            subnet_id,
-            provided_principals_count,
-        )))),
+        Err(e) => UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::RegistryError(e))),
     }
 }
 

--- a/src/subnet_rental_canister/src/external_calls.rs
+++ b/src/subnet_rental_canister/src/external_calls.rs
@@ -1,5 +1,7 @@
 use crate::canister_state::{cache_rate, get_cached_rate};
-use crate::external_types::{NotifyError, NotifyTopUpArg, SetAuthorizedSubnetworkListArgs};
+use crate::external_types::{
+    NotifyError, NotifyTopUpArg, SetAuthorizedSubnetworkListArgs, UpdateSubnetAdminsPayload,
+};
 use crate::{ExecuteProposalError, MEMO_TOP_UP_CANISTER};
 use candid::Principal;
 use ic_cdk::{call::Call, println};
@@ -17,6 +19,8 @@ use std::cell::RefCell;
 thread_local! {
     static EXCHANGE_RATE_CANISTER_ID: RefCell<Principal> =
         RefCell::new(Principal::from_text("uf6dk-hyaaa-aaaaq-qaaaq-cai").expect("Invalid XRC canister ID"));
+    static REGISTRY_CANISTER_ID: RefCell<Principal> =
+        RefCell::new(Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").expect("Invalid Registry canister ID"));
 }
 
 pub fn get_exchange_rate_canister_id() -> Principal {
@@ -168,4 +172,15 @@ pub async fn check_subaccount_balance(subaccount: Subaccount) -> Tokens {
         .expect("Failed to call LedgerCanister")
         .candid()
         .expect("Failed to decode result")
+}
+
+pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> Result<(), String> {
+    Call::unbounded_wait(
+        REGISTRY_CANISTER_ID.with_borrow(|p| *p),
+        "update_subnet_admins",
+    )
+    .with_arg(payload)
+    .await
+    .map(|_| ())
+    .map_err(|err| err.to_string())
 }

--- a/src/subnet_rental_canister/src/external_types.rs
+++ b/src/subnet_rental_canister/src/external_types.rs
@@ -1,4 +1,7 @@
-use candid::{CandidType, Deserialize, Principal};
+use candid::{
+    types::bounded_vec::{BoundedVec, UNBOUNDED},
+    CandidType, Deserialize, Principal,
+};
 use ic_ledger_types::Tokens;
 use std::collections::{HashMap, HashSet};
 
@@ -84,4 +87,34 @@ pub struct NnsLedgerCanisterInitPayload {
 #[derive(CandidType, Debug)]
 pub struct FeatureFlags {
     pub icrc2: bool,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub enum OperationType {
+    Add(BoundedVec<{ super::MAX_ALLOWED_SUBNET_ADMINS }, UNBOUNDED, UNBOUNDED, Principal>),
+    Remove(BoundedVec<{ super::MAX_ALLOWED_SUBNET_ADMINS }, UNBOUNDED, UNBOUNDED, Principal>),
+    Clear(candid::Reserved),
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct UpdateSubnetAdminsPayload {
+    pub subnet_id: Principal,
+    pub operation_type: Option<OperationType>,
+}
+
+impl From<crate::UpdateSubnetAdminsPayload> for UpdateSubnetAdminsPayload {
+    fn from(payload: crate::UpdateSubnetAdminsPayload) -> Self {
+        let operation_type = match payload.operation_type {
+            Some(crate::OperationType::Add(principal_list)) => OperationType::Add(principal_list),
+            Some(crate::OperationType::Remove(principal_list)) => {
+                OperationType::Remove(principal_list)
+            }
+            Some(crate::OperationType::Clear(_)) => OperationType::Clear(candid::Reserved),
+            None => OperationType::Clear(candid::Reserved),
+        };
+        UpdateSubnetAdminsPayload {
+            subnet_id: payload.subnet_id,
+            operation_type: Some(operation_type),
+        }
+    }
 }

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -224,38 +224,11 @@ pub struct UpdateSubnetAdminsPayload {
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub enum UpdateSubnetAdminsError {
-    TooManySubnetAdmins { provided: u64, max_allowed: u64 },
     CallerNotRentingSubnet(candid::Reserved),
     PrincipalListEmpty(candid::Reserved),
     ConcurrentChange(candid::Reserved),
     UnknownOperationType(candid::Reserved),
-    RateLimited(Principal),
-    UnknownError(String),
-}
-
-impl From<(String, Principal, u64)> for UpdateSubnetAdminsError {
-    fn from(
-        (error, subnet_id, provided_principals_count): (String, Principal, u64),
-    ) -> UpdateSubnetAdminsError {
-        // The error messages are taken from the Registry's [Display implementation]
-        // (https://github.com/dfinity/ic/blob/ebfc635d0956899f3d821ab25d3ed9463c74d055/rs/registry/canister/src/mutations/do_update_subnet_admins.rs#L53-L82)
-        // While this approach is not great, it's the best we can do given that
-        // the Registry canister panics and does not return structured errors.
-        // The following will have to be updated whenever a change happens
-        // on the Registry's side.
-        if error.contains("Too many subnet admins") {
-            UpdateSubnetAdminsError::TooManySubnetAdmins {
-                provided: provided_principals_count,
-                max_allowed: MAX_ALLOWED_SUBNET_ADMINS as u64,
-            }
-        } else if error.contains("The operation type provided is unknown") {
-            UpdateSubnetAdminsError::UnknownOperationType(candid::Reserved)
-        } else if error.contains("rate limited due to too many subnet admin updates") {
-            UpdateSubnetAdminsError::RateLimited(subnet_id)
-        } else {
-            UpdateSubnetAdminsError::UnknownError(format!("{error:?}"))
-        }
-    }
+    RegistryError(String),
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -1,4 +1,7 @@
-use candid::{CandidType, Decode, Deserialize, Encode, Principal};
+use candid::{
+    types::bounded_vec::{BoundedVec, UNBOUNDED},
+    CandidType, Decode, Deserialize, Encode, Principal,
+};
 use history::Event;
 use ic_ledger_types::{Memo, Tokens};
 use ic_stable_structures::{storable::Bound, Storable};
@@ -13,6 +16,7 @@ mod history;
 pub const BILLION: u64 = 1_000_000_000;
 pub const TRILLION: u128 = 1_000_000_000_000;
 pub const E8S: u64 = 100_000_000;
+const MAX_ALLOWED_SUBNET_ADMINS: usize = 10;
 const MEMO_TOP_UP_CANISTER: Memo = Memo(0x50555054); // == 'TPUP'
 
 // ============================================================================
@@ -203,4 +207,59 @@ pub struct EventPage {
     /// `get_history_page(principal, Some(continuation))` or
     /// `get_rental_conditions_history_page(Some(continuation))
     pub continuation: u64,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub enum OperationType {
+    Add(BoundedVec<MAX_ALLOWED_SUBNET_ADMINS, UNBOUNDED, UNBOUNDED, Principal>),
+    Remove(BoundedVec<MAX_ALLOWED_SUBNET_ADMINS, UNBOUNDED, UNBOUNDED, Principal>),
+    Clear(candid::Reserved),
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct UpdateSubnetAdminsPayload {
+    pub subnet_id: Principal,
+    pub operation_type: Option<OperationType>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub enum UpdateSubnetAdminsError {
+    TooManySubnetAdmins { provided: u64, max_allowed: u64 },
+    CallerNotRentingSubnet(candid::Reserved),
+    PrincipalListEmpty(candid::Reserved),
+    ConcurrentChange(candid::Reserved),
+    UnknownOperationType(candid::Reserved),
+    RateLimited(Principal),
+    UnknownError(String),
+}
+
+impl From<(String, Principal, u64)> for UpdateSubnetAdminsError {
+    fn from(
+        (error, subnet_id, provided_principals_count): (String, Principal, u64),
+    ) -> UpdateSubnetAdminsError {
+        // The error messages are taken from the Registry's [Display implementation]
+        // (https://github.com/dfinity/ic/blob/ebfc635d0956899f3d821ab25d3ed9463c74d055/rs/registry/canister/src/mutations/do_update_subnet_admins.rs#L53-L82)
+        // While this approach is not great, it's the best we can do given that
+        // the Registry canister panics and does not return structured errors.
+        // The following will have to be updated whenever a change happens
+        // on the Registry's side.
+        if error.contains("Too many subnet admins") {
+            UpdateSubnetAdminsError::TooManySubnetAdmins {
+                provided: provided_principals_count,
+                max_allowed: MAX_ALLOWED_SUBNET_ADMINS as u64,
+            }
+        } else if error.contains("The operation type provided is unknown") {
+            UpdateSubnetAdminsError::UnknownOperationType(candid::Reserved)
+        } else if error.contains("rate limited due to too many subnet admin updates") {
+            UpdateSubnetAdminsError::RateLimited(subnet_id)
+        } else {
+            UpdateSubnetAdminsError::UnknownError(format!("{error:?}"))
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub enum UpdateSubnetAdminsResult {
+    Ok(candid::Reserved),
+    Err(Option<UpdateSubnetAdminsError>),
 }

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -1291,12 +1291,12 @@ fn check_subnet_status(pic: &PocketIc) -> RentalAgreementStatus {
 
 fn rent_subnet_helper(pic: &PocketIc, subnet_id: Principal, renting_principal: Principal) {
     // set an exchange rate for the current time on the XRC mock
-    set_xrc_exchange_rate_last_midnight(&pic, 3_593_382_591); // 1 ICP = 3.593382591 XDR
-    let final_subnet_price = get_todays_price(&pic);
+    set_xrc_exchange_rate_last_midnight(pic, 3_593_382_591); // 1 ICP = 3.593382591 XDR
+    let final_subnet_price = get_todays_price(pic);
 
     // transfer the initial payment
     let paid_to_src = final_subnet_price + Tokens::from_e8s(100 * E8S); // 100 ICP extra
-    pay_src(&pic, renting_principal, paid_to_src);
+    pay_src(pic, renting_principal, paid_to_src);
 
     // create rental request proposal
     let now = pic.get_time().as_nanos_since_unix_epoch() / NANOS_PER_SECOND;
@@ -1315,7 +1315,7 @@ fn rent_subnet_helper(pic: &PocketIc, subnet_id: Principal, renting_principal: P
 
     // Submit the request to rent a subnet and execute it.
     update::<()>(
-        &pic,
+        pic,
         SRC_ID,
         Some(MAINNET_GOVERNANCE_CANISTER_ID),
         "execute_rental_request_proposal",
@@ -1329,7 +1329,7 @@ fn rent_subnet_helper(pic: &PocketIc, subnet_id: Principal, renting_principal: P
         proposal_id: 137322,
     };
     update::<()>(
-        &pic,
+        pic,
         SRC_ID,
         Some(MAINNET_GOVERNANCE_CANISTER_ID),
         "execute_create_rental_agreement",

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -1,10 +1,19 @@
-use candid::{decode_one, encode_args, encode_one, utils::ArgumentEncoder, CandidType, Principal};
+use candid::{
+    decode_one, encode_args, encode_one, types::bounded_vec::BoundedVec, utils::ArgumentEncoder,
+    CandidType, Principal,
+};
 use ic_ledger_types::{
     AccountBalanceArgs, AccountIdentifier, Memo, Subaccount, Tokens, TransferArgs, TransferResult,
     DEFAULT_FEE, DEFAULT_SUBACCOUNT, MAINNET_CYCLES_MINTING_CANISTER_ID,
     MAINNET_GOVERNANCE_CANISTER_ID, MAINNET_LEDGER_CANISTER_ID,
 };
-use pocket_ic::{PocketIc, PocketIcBuilder, Time};
+use pocket_ic::{
+    common::rest::{
+        CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, IcpFeatures, IcpFeaturesConfig,
+        SubnetSpec,
+    },
+    PocketIc, PocketIcBuilder, Time,
+};
 use serde::Deserialize;
 use std::{
     collections::{HashMap, HashSet},
@@ -17,9 +26,10 @@ use subnet_rental_canister::{
         CmcInitPayload, ExchangeRateCanister, FeatureFlags, NnsLedgerCanisterInitPayload,
         NnsLedgerCanisterPayload, PrincipalsAuthorizedToCreateCanistersToSubnetsResponse,
     },
-    CreateRentalAgreementPayload, EventPage, ExecuteProposalError, RentalAgreement,
+    CreateRentalAgreementPayload, EventPage, ExecuteProposalError, OperationType, RentalAgreement,
     RentalAgreementStatus, RentalConditionId, RentalConditions, RentalRequest,
-    SubnetRentalProposalPayload, TopUpSummary, E8S, TRILLION,
+    SubnetRentalProposalPayload, TopUpSummary, UpdateSubnetAdminsError, UpdateSubnetAdminsPayload,
+    UpdateSubnetAdminsResult, E8S, TRILLION,
 };
 
 const SRC_WASM: &str = "../../subnet_rental_canister.wasm.gz";
@@ -97,13 +107,7 @@ fn install_ledger(pic: &PocketIc) {
     );
 }
 
-fn setup() -> PocketIc {
-    let pic = PocketIcBuilder::new()
-        .with_nns_subnet()
-        // needed for XRC
-        .with_ii_subnet()
-        .build();
-
+fn setup_helper(pic: PocketIc) -> PocketIc {
     pic.set_time(Time::from_nanos_since_unix_epoch(
         1_620_633_600 * 1_000_000_000,
     )); // set time to make CMC fetch the first rate properly from the XRC
@@ -117,6 +121,35 @@ fn setup() -> PocketIc {
     pic.install_canister(subnet_rental_canister, src_wasm, vec![], None);
     pic.add_cycles(subnet_rental_canister, INITIAL_SRC_CYCLES_BALANCE);
     pic
+}
+
+fn setup() -> PocketIc {
+    let pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        // needed for XRC
+        .with_ii_subnet()
+        .build();
+
+    setup_helper(pic)
+}
+
+fn setup_with_rented_subnet() -> PocketIc {
+    let subnet_spec = SubnetSpec::default().with_cost_schedule(CanisterCyclesCostSchedule::Free);
+    let subnet_config = ExtendedSubnetConfigSet {
+        application: vec![subnet_spec],
+        ..Default::default()
+    };
+    let pic = PocketIcBuilder::new_with_config(subnet_config)
+        .with_nns_subnet()
+        // needed for XRC
+        .with_ii_subnet()
+        .with_icp_features(IcpFeatures {
+            registry: Some(IcpFeaturesConfig::DefaultConfig),
+            ..Default::default()
+        })
+        .build();
+
+    setup_helper(pic)
 }
 
 fn get_todays_price(pic: &PocketIc) -> Tokens {
@@ -977,6 +1010,179 @@ fn test_accept_rental_agreement_cannot_be_called_by_non_governance() {
         .contains(&format!("{:?}", ExecuteProposalError::UnauthorizedCaller)));
 }
 
+#[test]
+fn update_subnet_admins_cannot_be_called_by_non_renting_principal() {
+    let pic = setup();
+    let user_principal = USER_1;
+    let payload = UpdateSubnetAdminsPayload {
+        subnet_id: SUBNET_FOR_RENT,
+        operation_type: Some(OperationType::Add(BoundedVec::new(vec![USER_2]))),
+    };
+    let res = update::<UpdateSubnetAdminsResult>(
+        &pic,
+        SRC_ID,
+        Some(user_principal),
+        "update_subnet_admins",
+        payload,
+    );
+    assert_eq!(
+        res.unwrap(),
+        UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::CallerNotRentingSubnet(
+            candid::Reserved
+        ))),
+    );
+}
+
+#[test]
+fn list_of_subnet_admins_to_add_or_remove_cannot_be_empty() {
+    let pic = setup_with_rented_subnet();
+
+    // There should only be one application subnet that has a free
+    // cost schedule returned by `setup_with_rented_subnet()`.
+    let subnet_id = *pic.topology().get_app_subnets().first().unwrap();
+
+    let renting_principal = USER_1;
+    rent_subnet_helper(&pic, subnet_id, renting_principal);
+
+    let payload = UpdateSubnetAdminsPayload {
+        subnet_id,
+        operation_type: Some(OperationType::Add(BoundedVec::new(vec![]))),
+    };
+    let res = update::<UpdateSubnetAdminsResult>(
+        &pic,
+        SRC_ID,
+        Some(USER_1),
+        "update_subnet_admins",
+        payload,
+    );
+    assert_eq!(
+        res.unwrap(),
+        UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::PrincipalListEmpty(
+            candid::Reserved
+        )))
+    );
+
+    let payload = UpdateSubnetAdminsPayload {
+        subnet_id,
+        operation_type: Some(OperationType::Remove(BoundedVec::new(vec![]))),
+    };
+    let res = update::<UpdateSubnetAdminsResult>(
+        &pic,
+        SRC_ID,
+        Some(renting_principal),
+        "update_subnet_admins",
+        payload,
+    );
+    assert_eq!(
+        res.unwrap(),
+        UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::PrincipalListEmpty(
+            candid::Reserved
+        )))
+    );
+}
+
+#[test]
+fn can_update_subnet_admins_when_renting_subnet() {
+    let pic = setup_with_rented_subnet();
+
+    // There should only be one application subnet that has a free
+    // cost schedule returned by `setup_with_rented_subnet()`.
+    let subnet_id = *pic.topology().get_app_subnets().first().unwrap();
+
+    let renting_principal = USER_1;
+    rent_subnet_helper(&pic, subnet_id, renting_principal);
+
+    let payload = UpdateSubnetAdminsPayload {
+        subnet_id,
+        operation_type: Some(OperationType::Add(BoundedVec::new(vec![
+            renting_principal,
+            USER_2,
+        ]))),
+    };
+    let res = update::<UpdateSubnetAdminsResult>(
+        &pic,
+        SRC_ID,
+        Some(renting_principal),
+        "update_subnet_admins",
+        payload,
+    );
+    assert_eq!(res.unwrap(), UpdateSubnetAdminsResult::Ok(candid::Reserved));
+
+    let payload = UpdateSubnetAdminsPayload {
+        subnet_id,
+        operation_type: Some(OperationType::Remove(BoundedVec::new(vec![USER_2]))),
+    };
+    let res = update::<UpdateSubnetAdminsResult>(
+        &pic,
+        SRC_ID,
+        Some(renting_principal),
+        "update_subnet_admins",
+        payload,
+    );
+    assert_eq!(res.unwrap(), UpdateSubnetAdminsResult::Ok(candid::Reserved));
+}
+
+#[test]
+fn do_not_allow_concurrent_subnet_admin_updates() {
+    let pic = setup_with_rented_subnet();
+
+    // There should only be one application subnet that has a free
+    // cost schedule returned by `setup_with_rented_subnet()`.
+    let subnet_id = *pic.topology().get_app_subnets().first().unwrap();
+
+    rent_subnet_helper(&pic, subnet_id, USER_1);
+
+    // Prepare and submit two messages to concurrently update subnet admins.
+    // One of them should succeed and one should fail.
+    let user_principal = USER_1;
+    let payload = UpdateSubnetAdminsPayload {
+        subnet_id,
+        operation_type: Some(OperationType::Add(BoundedVec::new(vec![USER_2]))),
+    };
+
+    let msg_id1 = pic
+        .submit_call(
+            SRC_ID,
+            user_principal,
+            "update_subnet_admins",
+            encode_one(payload.clone()).unwrap(),
+        )
+        .unwrap();
+    let msg_id2 = pic
+        .submit_call(
+            SRC_ID,
+            user_principal,
+            "update_subnet_admins",
+            encode_one(payload).unwrap(),
+        )
+        .unwrap();
+
+    let mut results = vec![];
+
+    // Trigger concurrent execution of both update calls and block until the
+    // first one completes.
+    let res1 = pic.await_call(msg_id1).unwrap();
+    let decoded_res1 = decode_one::<UpdateSubnetAdminsResult>(&res1).unwrap();
+    results.push(decoded_res1);
+
+    // Resume execution of the second update call if it has not completed yet
+    // and block until it completes
+    let res2 = pic.await_call(msg_id2).unwrap();
+    let decoded_res2 = decode_one::<UpdateSubnetAdminsResult>(&res2).unwrap();
+    results.push(decoded_res2);
+
+    assert!(
+        results.contains(&UpdateSubnetAdminsResult::Ok(candid::Reserved)),
+        "One call should have succeeded but got {results:?}"
+    );
+    assert!(
+        results.contains(&UpdateSubnetAdminsResult::Err(Some(
+            UpdateSubnetAdminsError::ConcurrentChange(candid::Reserved)
+        ))),
+        "One call should have failed due to concurrent changes but got {results:?}"
+    );
+}
+
 // TODO
 // fn test_proposal_rejected_if_already_rented() {
 // fn test_burning() {
@@ -1081,4 +1287,53 @@ fn check_subnet_status(pic: &PocketIc) -> RentalAgreementStatus {
         SUBNET_FOR_RENT,
     )
     .unwrap()
+}
+
+fn rent_subnet_helper(pic: &PocketIc, subnet_id: Principal, renting_principal: Principal) {
+    // set an exchange rate for the current time on the XRC mock
+    set_xrc_exchange_rate_last_midnight(&pic, 3_593_382_591); // 1 ICP = 3.593382591 XDR
+    let final_subnet_price = get_todays_price(&pic);
+
+    // transfer the initial payment
+    let paid_to_src = final_subnet_price + Tokens::from_e8s(100 * E8S); // 100 ICP extra
+    pay_src(&pic, renting_principal, paid_to_src);
+
+    // create rental request proposal
+    let now = pic.get_time().as_nanos_since_unix_epoch() / NANOS_PER_SECOND;
+    let payload = SubnetRentalProposalPayload {
+        user: renting_principal,
+        rental_condition_id: RentalConditionId::App13CH,
+        proposal_id: 136408,
+        proposal_creation_time_seconds: now,
+    };
+
+    // 1 day passes ...
+    pic.advance_time(Duration::from_secs(SECONDS_PER_DAY));
+    for _ in 0..3 {
+        pic.tick();
+    }
+
+    // Submit the request to rent a subnet and execute it.
+    update::<()>(
+        &pic,
+        SRC_ID,
+        Some(MAINNET_GOVERNANCE_CANISTER_ID),
+        "execute_rental_request_proposal",
+        payload.clone(),
+    )
+    .unwrap();
+
+    let payload = CreateRentalAgreementPayload {
+        user: renting_principal,
+        subnet_id,
+        proposal_id: 137322,
+    };
+    update::<()>(
+        &pic,
+        SRC_ID,
+        Some(MAINNET_GOVERNANCE_CANISTER_ID),
+        "execute_create_rental_agreement",
+        payload.clone(),
+    )
+    .unwrap();
 }


### PR DESCRIPTION
This PR adds supporting for updating the list of subnet admins for a rented subnet via the SRC. Only the principal renting a subnet can update admins for this subnet. The new API added is forwarding the request to the Registry canister which is doing the heavy lifting along with some extra checks that the SRC implements, like making sure the subnet is rented or that there cannot be multiple such requests in flight.

About half of the changes are the tests that are added to make sure that things work as expected, the remaining production code should be rather straightforward.