### PR TITLE
feat: emit events for all state-changing endpoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !Dockerfile
+!rust-toolchain.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,8 @@ RUN rm candid-extractor.tar.gz
 RUN chmod +x candid-extractor
 RUN mv candid-extractor /usr/local/bin/candid-extractor
 
+# Install toolchain from rust-toolchain.toml (includes wasm target, clippy, rustfmt)
+COPY rust-toolchain.toml /tmp/rust-toolchain.toml
+RUN cd /tmp && rustup show
+
 WORKDIR /app

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -781,21 +781,44 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
     let user_icp_balance = check_subaccount_balance(Subaccount::from(rental_agreement.user)).await;
 
     if user_icp_balance < DEFAULT_FEE {
-        return Err(format!(
+        let reason = format!(
             "Failed to top up: {} has insufficient funds {}",
             rental_agreement.user, user_icp_balance
-        ));
+        );
+        persist_event(
+            EventType::SubnetTopUpFailed {
+                subnet_id,
+                user: rental_agreement.user,
+                reason: reason.clone(),
+            },
+            Some(subnet_id),
+        );
+        return Err(reason);
     }
 
     let icp_amount_for_cycles = user_icp_balance - DEFAULT_FEE;
 
     // If the user were to withdraw before this call, the function would return an error.
-    let (block_index, actual_cycles) = convert_icp_to_cycles(
+    let (block_index, actual_cycles) = match convert_icp_to_cycles(
         icp_amount_for_cycles,
         Subaccount::from(rental_agreement.user),
     )
     .await
-    .map_err(|e| format!("Failed to convert ICP to cycles: {:?}", e))?;
+    {
+        Ok(v) => v,
+        Err(e) => {
+            let reason = format!("Failed to convert ICP to cycles: {:?}", e);
+            persist_event(
+                EventType::SubnetTopUpFailed {
+                    subnet_id,
+                    user: rental_agreement.user,
+                    reason: reason.clone(),
+                },
+                Some(subnet_id),
+            );
+            return Err(reason);
+        }
+    };
     persist_event(
         EventType::TransferSuccess {
             amount: icp_amount_for_cycles,

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -191,9 +191,9 @@ async fn locking() {
         };
 
         // Convert ICP to cycles.
-        let locked_cycles =
+        let (block_index, locked_cycles) =
             match convert_icp_to_cycles(ten_percent_icp, Subaccount::from(user)).await {
-                Ok(locked_cycles) => locked_cycles,
+                Ok(result) => result,
                 Err(error) => {
                     println!("Failed to convert ICP to cycles for rental request of user {user}.");
                     persist_event(
@@ -207,6 +207,13 @@ async fn locking() {
                 }
             };
 
+        persist_event(
+            EventType::TransferSuccess {
+                amount: ten_percent_icp,
+                block_index,
+            },
+            Some(user),
+        );
         println!("SRC gained {locked_cycles} cycles from the locked ICP.");
         persist_event(
             EventType::LockingSuccess {
@@ -539,11 +546,18 @@ pub async fn execute_rental_request_proposal(payload: SubnetRentalProposalPayloa
         );
 
         let res = convert_icp_to_cycles(lock_amount_icp, Subaccount::from(user)).await;
-        let Ok(locked_cycles) = res else {
+        let Ok((block_index, locked_cycles)) = res else {
             println!("Fatal: Failed to convert ICP to cycles");
             let e = res.unwrap_err();
             return with_error(user, proposal_id, e);
         };
+        persist_event(
+            EventType::TransferSuccess {
+                amount: lock_amount_icp,
+                block_index,
+            },
+            Some(user),
+        );
         println!("SRC gained {} cycles from the locked ICP.", locked_cycles);
 
         let now_nanos = ic_cdk::api::time();
@@ -603,8 +617,15 @@ pub async fn execute_create_rental_agreement(payload: CreateRentalAgreementPaylo
 
         // Convert all remaining ICP to cycles.
         let remaining_icp = rental_request.initial_cost_icp - rental_request.locked_amount_icp;
-        let converted_cycles =
+        let (block_index, converted_cycles) =
             convert_icp_to_cycles(remaining_icp, Subaccount::from(payload.user)).await?;
+        persist_event(
+            EventType::TransferSuccess {
+                amount: remaining_icp,
+                block_index,
+            },
+            Some(payload.user),
+        );
         let total_cycles_created =
             converted_cycles.saturating_add(rental_request.locked_amount_cycles);
 
@@ -665,6 +686,13 @@ pub async fn refund() -> Result<u64, String> {
             to_be_refunded, caller, e
         )
     })?;
+    persist_event(
+        EventType::TransferSuccess {
+            amount: to_be_refunded,
+            block_index: block_id,
+        },
+        Some(caller),
+    );
 
     // If the user has a rental request, burn the locked cycles and remove the request.
     if let Some(rental_request) = get_rental_request(&caller) {
@@ -762,12 +790,19 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
     let icp_amount_for_cycles = user_icp_balance - DEFAULT_FEE;
 
     // If the user were to withdraw before this call, the function would return an error.
-    let actual_cycles = convert_icp_to_cycles(
+    let (block_index, actual_cycles) = convert_icp_to_cycles(
         icp_amount_for_cycles,
         Subaccount::from(rental_agreement.user),
     )
     .await
     .map_err(|e| format!("Failed to convert ICP to cycles: {:?}", e))?;
+    persist_event(
+        EventType::TransferSuccess {
+            amount: icp_amount_for_cycles,
+            block_index,
+        },
+        Some(subnet_id),
+    );
     println!(
         "Converted {} ICP to {} cycles",
         icp_amount_for_cycles, actual_cycles
@@ -813,6 +848,18 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
     })
     .unwrap(); // Safe because we checked above that the rental agreement exists.
 
+    persist_event(
+        EventType::SubnetTopUp {
+            subnet_id,
+            user: rental_agreement.user,
+            icp_amount: user_icp_balance,
+            cycles_added: actual_cycles,
+            days_added,
+            new_paid_until_nanos,
+        },
+        Some(subnet_id),
+    );
+
     let description = format!(
         "Topped up subnet {} with {} ICP corresponding to {} cycles, \
         extending the rental agreement by {} days",
@@ -854,7 +901,7 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
         )));
     };
 
-    match &payload.operation_type {
+    let operation = match &payload.operation_type {
         None => {
             return UpdateSubnetAdminsResult::Err(Some(
                 UpdateSubnetAdminsError::UnknownOperationType(candid::Reserved),
@@ -867,14 +914,36 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
                     UpdateSubnetAdminsError::PrincipalListEmpty(candid::Reserved),
                 ));
             }
+            payload.operation_type.clone().unwrap()
         }
-        Some(OperationType::Clear(_)) => {}
+        Some(OperationType::Clear(_)) => payload.operation_type.clone().unwrap(),
     };
 
+    let caller = msg_caller();
     let res = crate::external_calls::update_subnet_admins(payload.into()).await;
     match res {
-        Ok(()) => UpdateSubnetAdminsResult::Ok(candid::Reserved),
-        Err(e) => UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::RegistryError(e))),
+        Ok(()) => {
+            persist_event(
+                EventType::SubnetAdminsUpdated {
+                    subnet_id,
+                    caller,
+                    operation,
+                },
+                Some(subnet_id),
+            );
+            UpdateSubnetAdminsResult::Ok(candid::Reserved)
+        }
+        Err(e) => {
+            persist_event(
+                EventType::SubnetAdminsUpdateFailed {
+                    subnet_id,
+                    caller,
+                    reason: e.clone(),
+                },
+                Some(subnet_id),
+            );
+            UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::RegistryError(e)))
+        }
     }
 }
 

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -924,7 +924,7 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
         )));
     };
 
-    let operation = match &payload.operation_type {
+    match &payload.operation_type {
         None => {
             return UpdateSubnetAdminsResult::Err(Some(
                 UpdateSubnetAdminsError::UnknownOperationType(candid::Reserved),
@@ -937,36 +937,14 @@ pub async fn update_subnet_admins(payload: UpdateSubnetAdminsPayload) -> UpdateS
                     UpdateSubnetAdminsError::PrincipalListEmpty(candid::Reserved),
                 ));
             }
-            payload.operation_type.clone().unwrap()
         }
-        Some(OperationType::Clear(_)) => payload.operation_type.clone().unwrap(),
-    };
+        Some(OperationType::Clear(_)) => {}
+    }
 
-    let caller = msg_caller();
     let res = crate::external_calls::update_subnet_admins(payload.into()).await;
     match res {
-        Ok(()) => {
-            persist_event(
-                EventType::SubnetAdminsUpdated {
-                    subnet_id,
-                    caller,
-                    operation,
-                },
-                Some(subnet_id),
-            );
-            UpdateSubnetAdminsResult::Ok(candid::Reserved)
-        }
-        Err(e) => {
-            persist_event(
-                EventType::SubnetAdminsUpdateFailed {
-                    subnet_id,
-                    caller,
-                    reason: e.clone(),
-                },
-                Some(subnet_id),
-            );
-            UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::RegistryError(e)))
-        }
+        Ok(()) => UpdateSubnetAdminsResult::Ok(candid::Reserved),
+        Err(e) => UpdateSubnetAdminsResult::Err(Some(UpdateSubnetAdminsError::RegistryError(e))),
     }
 }
 

--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -788,7 +788,6 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
         );
         persist_event(
             EventType::SubnetTopUpFailed {
-                subnet_id,
                 user: rental_agreement.user,
                 reason: reason.clone(),
             },
@@ -811,7 +810,6 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
             let reason = format!("Failed to convert ICP to cycles: {:?}", e);
             persist_event(
                 EventType::SubnetTopUpFailed {
-                    subnet_id,
                     user: rental_agreement.user,
                     reason: reason.clone(),
                 },
@@ -874,7 +872,6 @@ pub async fn top_up_subnet(subnet_id: Principal) -> Result<TopUpSummary, String>
 
     persist_event(
         EventType::SubnetTopUp {
-            subnet_id,
             user: rental_agreement.user,
             icp_amount: user_icp_balance,
             cycles_added: actual_cycles,

--- a/src/subnet_rental_canister/src/external_calls.rs
+++ b/src/subnet_rental_canister/src/external_calls.rs
@@ -139,11 +139,11 @@ pub async fn get_exchange_rate_icp_per_xdr_at_time(
 }
 
 /// Converts ICP from a user's SRC subaccount to cycles.
-/// Returns the actual amount of cycles created.
+/// Returns the block index of the transfer and the actual amount of cycles created.
 pub async fn convert_icp_to_cycles(
     amount: Tokens,
     source: Subaccount,
-) -> Result<u128, ExecuteProposalError> {
+) -> Result<(u64, u128), ExecuteProposalError> {
     // Transfer the ICP from the SRC to the CMC.
     let transfer_to_cmc_result = transfer_to_cmc(amount - DEFAULT_FEE, source).await;
     let Ok(block_index) = transfer_to_cmc_result else {
@@ -159,7 +159,7 @@ pub async fn convert_icp_to_cycles(
         println!("Notify top-up failed: {:?}", e);
         return Err(ExecuteProposalError::NotifyTopUpError(format!("{:?}", e)));
     };
-    Ok(actual_cycles)
+    Ok((block_index, actual_cycles))
 }
 
 /// Check balance of a user's SRC subaccount.

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -1,4 +1,4 @@
-use crate::{Principal, RentalConditionId, RentalConditions, RentalRequest};
+use crate::{OperationType, Principal, RentalConditionId, RentalConditions, RentalRequest};
 use candid::{CandidType, Decode, Encode};
 use ic_ledger_types::Tokens;
 use ic_stable_structures::{storable::Bound, Storable};
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 /// Important events are persisted for auditing by the community.
 /// Create events via EventType::SomeVariant.into()
 /// so that system time is captured automatically.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, CandidType, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
 pub struct Event {
     time_nanos: u64,
     event: EventType,
@@ -50,7 +50,7 @@ impl From<EventType> for Event {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, CandidType, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
 pub enum EventType {
     /// Changed via code upgrade, which should create this event in the post-upgrade hook.
     /// A None value means that the entry has been removed from the map.
@@ -80,6 +80,7 @@ pub enum EventType {
         subnet_creation_proposal_id: Option<u64>,
         rental_condition_id: RentalConditionId,
     },
+    /// Not yet emitted. Reserved for future rental agreement termination logic.
     RentalAgreementTerminated {
         user: Principal,
         initial_proposal_id: u64,
@@ -91,11 +92,13 @@ pub enum EventType {
         amount: Tokens,
         block_index: u64,
     },
+    /// Not yet emitted. Reserved for future recurring payment logic.
     PaymentSuccess {
         amount: Tokens,
         cycles: u128,
         covered_until_nanos: u64,
     },
+    /// Not yet emitted. Reserved for future recurring payment logic.
     PaymentFailure {
         reason: String,
     },
@@ -110,7 +113,27 @@ pub enum EventType {
         user: Principal,
         reason: String,
     },
+    SubnetTopUp {
+        subnet_id: Principal,
+        user: Principal,
+        icp_amount: Tokens,
+        cycles_added: u128,
+        days_added: u64,
+        new_paid_until_nanos: u64,
+    },
+    SubnetAdminsUpdated {
+        subnet_id: Principal,
+        caller: Principal,
+        operation: OperationType,
+    },
+    SubnetAdminsUpdateFailed {
+        subnet_id: Principal,
+        caller: Principal,
+        reason: String,
+    },
+    /// Not yet emitted. Reserved for future canister degradation detection.
     Degraded,
+    /// Not yet emitted. Reserved for future canister degradation recovery.
     Undegraded,
     Other {
         message: String,

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -92,16 +92,6 @@ pub enum EventType {
         amount: Tokens,
         block_index: u64,
     },
-    /// Not yet emitted. Reserved for future recurring payment logic.
-    PaymentSuccess {
-        amount: Tokens,
-        cycles: u128,
-        covered_until_nanos: u64,
-    },
-    /// Not yet emitted. Reserved for future recurring payment logic.
-    PaymentFailure {
-        reason: String,
-    },
     /// A successfull locking of 10% during the wait until subnet creation.
     LockingSuccess {
         user: Principal,
@@ -113,6 +103,7 @@ pub enum EventType {
         user: Principal,
         reason: String,
     },
+    /// A successful top-up of a rented subnet, converting ICP to cycles and extending the rental period.
     SubnetTopUp {
         subnet_id: Principal,
         user: Principal,
@@ -121,11 +112,19 @@ pub enum EventType {
         days_added: u64,
         new_paid_until_nanos: u64,
     },
+    /// A failed top-up attempt for a rented subnet (insufficient funds or ICP-to-cycles conversion error).
+    SubnetTopUpFailed {
+        subnet_id: Principal,
+        user: Principal,
+        reason: String,
+    },
+    /// A successful update of the subnet admins list by the renting principal.
     SubnetAdminsUpdated {
         subnet_id: Principal,
         caller: Principal,
         operation: OperationType,
     },
+    /// A failed attempt to update the subnet admins list.
     SubnetAdminsUpdateFailed {
         subnet_id: Principal,
         caller: Principal,

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -1,4 +1,4 @@
-use crate::{OperationType, Principal, RentalConditionId, RentalConditions, RentalRequest};
+use crate::{Principal, RentalConditionId, RentalConditions, RentalRequest};
 use candid::{CandidType, Decode, Encode};
 use ic_ledger_types::Tokens;
 use ic_stable_structures::{storable::Bound, Storable};
@@ -116,18 +116,6 @@ pub enum EventType {
     SubnetTopUpFailed {
         subnet_id: Principal,
         user: Principal,
-        reason: String,
-    },
-    /// A successful update of the subnet admins list by the renting principal.
-    SubnetAdminsUpdated {
-        subnet_id: Principal,
-        caller: Principal,
-        operation: OperationType,
-    },
-    /// A failed attempt to update the subnet admins list.
-    SubnetAdminsUpdateFailed {
-        subnet_id: Principal,
-        caller: Principal,
         reason: String,
     },
     /// Not yet emitted. Reserved for future canister degradation detection.

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -118,9 +118,9 @@ pub enum EventType {
         user: Principal,
         reason: String,
     },
-    /// Not yet emitted. Reserved for future canister degradation detection.
+    /// Not yet emitted. Reserved for future subnet degradation.
     Degraded,
-    /// Not yet emitted. Reserved for future canister degradation recovery.
+    /// Not yet emitted. Reserved for future subnet degradation recovery.
     Undegraded,
     Other {
         message: String,

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -105,7 +105,6 @@ pub enum EventType {
     },
     /// A successful top-up of a rented subnet, converting ICP to cycles and extending the rental period.
     SubnetTopUp {
-        subnet_id: Principal,
         user: Principal,
         icp_amount: Tokens,
         cycles_added: u128,
@@ -114,7 +113,6 @@ pub enum EventType {
     },
     /// A failed top-up attempt for a rented subnet (insufficient funds or ICP-to-cycles conversion error).
     SubnetTopUpFailed {
-        subnet_id: Principal,
         user: Principal,
         reason: String,
     },

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -689,6 +689,16 @@ fn test_create_rental_agreement() {
     .unwrap()
     .unwrap();
 
+    // capture the subnet history length before attempting top-ups
+    let subnet_history_before = query_multi_arg::<EventPage>(
+        &pic,
+        SRC_ID,
+        None,
+        "get_history_page",
+        (SUBNET_FOR_RENT, None::<Option<u64>>),
+    );
+    let subnet_events_before = subnet_history_before.events.len();
+
     // try to do topup with insufficient funds
     let res = update::<Result<TopUpSummary, String>>(
         &pic,
@@ -701,6 +711,19 @@ fn test_create_rental_agreement() {
 
     // the conversion should fail as the user does not have any ICP
     assert!(res.unwrap_err().contains("insufficient funds"));
+
+    // the failed top-up should persist a SubnetTopUpFailed event on the subnet
+    let subnet_history_after_failure = query_multi_arg::<EventPage>(
+        &pic,
+        SRC_ID,
+        None,
+        "get_history_page",
+        (SUBNET_FOR_RENT, None::<Option<u64>>),
+    );
+    assert_eq!(
+        subnet_history_after_failure.events.len(),
+        subnet_events_before + 1
+    );
 
     // top up SRC account with 1000 ICP
     let topup = Tokens::from_e8s(1_000 * E8S);
@@ -715,6 +738,19 @@ fn test_create_rental_agreement() {
     )
     .unwrap()
     .unwrap();
+
+    // the successful top-up should persist TransferSuccess + SubnetTopUp events on the subnet
+    let subnet_history_after_success = query_multi_arg::<EventPage>(
+        &pic,
+        SRC_ID,
+        None,
+        "get_history_page",
+        (SUBNET_FOR_RENT, None::<Option<u64>>),
+    );
+    assert_eq!(
+        subnet_history_after_success.events.len(),
+        subnet_events_before + 3
+    );
 
     // check that the user's balance has decreased by exactly the amount for the topup plus the fee
     let users_balance_after_topup = check_balance(&pic, USER_1, DEFAULT_SUBACCOUNT);

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -324,9 +324,10 @@ fn test_initial_proposal() {
         "get_history_page",
         (user_principal, None::<Option<u64>>),
     );
-    // think of a better test than length
+    // 1 RentalConditionsChanged
     assert_eq!(src_history.events.len(), 1);
-    assert_eq!(user_history.events.len(), 1);
+    // 1 RentalRequestCreated + 1 TransferSuccess (initial 10% lock)
+    assert_eq!(user_history.events.len(), 2);
 
     let rental_requests =
         query::<Vec<RentalRequest>>(&pic, SRC_ID, None, "list_rental_requests", ());
@@ -977,7 +978,9 @@ fn test_locking() {
 
     // in total, we might have an error of strictly less than 10 e8s
     assert!(updated_rental_request.locked_amount_icp >= initial_payment - Tokens::from_e8s(10));
-    // there should be 1 rental request created event + 9 locking events (the last call should not have caused an event)
+    // 1 RentalRequestCreated + 1 TransferSuccess (initial lock) +
+    // 9 successful locking iterations * (1 TransferSuccess + 1 LockingSuccess) = 20
+    // (the last iteration should not have caused an event since 100% is already locked)
     let user_history = query_multi_arg::<EventPage>(
         &pic,
         SRC_ID,
@@ -985,7 +988,7 @@ fn test_locking() {
         "get_history_page",
         (user_principal, None::<Option<u64>>),
     );
-    assert_eq!(user_history.events.len(), 10);
+    assert_eq!(user_history.events.len(), 20);
 }
 
 #[test]


### PR DESCRIPTION
Wire up TransferSuccess at all ICP transfer sites, add new SubnetTopUp and SubnetAdminsUpdated/Failed events, and document unused event variants as reserved for future use.