### PR TITLE
feat: add App7CH rental condition and migrate Swiss Subnet to it

### DIFF
--- a/src/subnet_rental_canister/src/canister.rs
+++ b/src/subnet_rental_canister/src/canister.rs
@@ -10,11 +10,11 @@ use crate::{
         refund_user, set_authorized_subnetwork_list,
     },
     history::EventType,
-    CreateRentalAgreementPayload, EventPage, ExecuteProposalError, OperationType,
+    migration, CreateRentalAgreementPayload, EventPage, ExecuteProposalError, OperationType,
     PriceCalculationData, RentalAgreement, RentalAgreementStatus, RentalConditionId,
     RentalConditions, RentalRequest, SubnetRentalProposalPayload, TopUpSummary,
     UpdateSubnetAdminsError, UpdateSubnetAdminsPayload, UpdateSubnetAdminsResult, BILLION,
-    TRILLION,
+    SECONDS_PER_DAY, TRILLION,
 };
 use candid::Principal;
 use ic_cdk::{
@@ -27,7 +27,8 @@ use ic_ledger_types::{
 use std::{cmp::min, time::Duration};
 
 const CYCLES_BURN_INTERVAL_SECONDS: u64 = 60;
-const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+const INITIAL_RENTAL_PERIOD_DAYS: u64 = 180;
+const SWISS_NODES_DESCRIPTION: &str = "All nodes must be in Switzerland or Liechtenstein.";
 
 ////////// CANISTER METHODS //////////
 
@@ -41,20 +42,33 @@ fn init() {
 #[post_upgrade]
 async fn post_upgrade() {
     set_initial_conditions();
+    migration::app13ch_to_app7ch();
     start_timers();
 }
 
 /// Persist initial rental conditions in global map and history.
 fn set_initial_conditions() {
-    let initial_conditions = [(
-        RentalConditionId::App13CH,
-        RentalConditions {
-            description: "All nodes must be in Switzerland or Liechtenstein.".to_string(),
-            subnet_id: None,
-            daily_cost_cycles: 820 * TRILLION,
-            initial_rental_period_days: 180,
-        },
-    )];
+    let initial_conditions = [
+        (
+            RentalConditionId::App13CH,
+            RentalConditions {
+                description: SWISS_NODES_DESCRIPTION.to_string(),
+                subnet_id: None,
+                daily_cost_cycles: 820 * TRILLION,
+                initial_rental_period_days: INITIAL_RENTAL_PERIOD_DAYS,
+            },
+        ),
+        (
+            RentalConditionId::App7CH,
+            RentalConditions {
+                description: SWISS_NODES_DESCRIPTION.to_string(),
+                subnet_id: None,
+                // TODO: check. Approximates 820 / 13 * 7 (441.54), rounded down.
+                daily_cost_cycles: 440 * TRILLION,
+                initial_rental_period_days: INITIAL_RENTAL_PERIOD_DAYS,
+            },
+        ),
+    ];
     for (k, v) in initial_conditions.iter() {
         println!("Created initial rental condition {:?}: {:?}", k, v);
         insert_rental_condition(*k, v.clone());

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -119,7 +119,6 @@ pub enum EventType {
     /// A rental agreement moved to another rental condition, repricing the
     /// unburned cycles at the new daily cost.
     RentalConditionSwitched {
-        subnet_id: Principal,
         user: Principal,
         old_condition_id: RentalConditionId,
         new_condition_id: RentalConditionId,

--- a/src/subnet_rental_canister/src/history.rs
+++ b/src/subnet_rental_canister/src/history.rs
@@ -116,6 +116,17 @@ pub enum EventType {
         user: Principal,
         reason: String,
     },
+    /// A rental agreement moved to another rental condition, repricing the
+    /// unburned cycles at the new daily cost.
+    RentalConditionSwitched {
+        subnet_id: Principal,
+        user: Principal,
+        old_condition_id: RentalConditionId,
+        new_condition_id: RentalConditionId,
+        cycles_remaining: u128,
+        old_paid_until_nanos: u64,
+        new_paid_until_nanos: u64,
+    },
     /// Not yet emitted. Reserved for future subnet degradation.
     Degraded,
     /// Not yet emitted. Reserved for future subnet degradation recovery.

--- a/src/subnet_rental_canister/src/lib.rs
+++ b/src/subnet_rental_canister/src/lib.rs
@@ -12,8 +12,12 @@ mod canister_state;
 pub mod external_calls;
 pub mod external_types;
 mod history;
+mod migration;
+
+pub use migration::TARGET_SUBNET as MIGRATION_TARGET_SUBNET;
 
 pub const BILLION: u64 = 1_000_000_000;
+pub const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
 pub const TRILLION: u128 = 1_000_000_000_000;
 pub const E8S: u64 = 100_000_000;
 const MAX_ALLOWED_SUBNET_ADMINS: usize = 10;
@@ -26,6 +30,7 @@ const MEMO_TOP_UP_CANISTER: Memo = Memo(0x50555054); // == 'TPUP'
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, CandidType, Deserialize, Hash)]
 pub enum RentalConditionId {
     App13CH,
+    App7CH,
 }
 
 /// Set of conditions for a subnet up for rent.

--- a/src/subnet_rental_canister/src/migration.rs
+++ b/src/subnet_rental_canister/src/migration.rs
@@ -1,0 +1,182 @@
+//! One-shot state migrations that run in `post_upgrade`.
+//!
+//! # Why a migration and not an endpoint
+//!
+//! Moving a rental agreement to a different rental condition is not something the renter
+//! decides unilaterally: the SRC does not enforce subnet topology, so the billing change
+//! only makes sense alongside a registry change that shrinks the subnet. Exposing it as a
+//! public endpoint would let a renter reprice their agreement without the corresponding
+//! topology change, so instead the switch is performed once, as part of the upgrade that
+//! accompanies an NNS proposal.
+//!
+//! # Idempotency
+//!
+//! Each migration keys off state that the migration itself changes, so re-running it is a
+//! no-op. No migration-version counter is stored: a second upgrade simply finds nothing
+//! left to do. This matters because `post_upgrade` runs on *every* upgrade, not just the
+//! one that ships the migration.
+//!
+//! # Lifetime
+//!
+//! These functions are expected to be deleted once the migration has been applied on
+//! mainnet and the result has been verified.
+
+use crate::{
+    canister_state::{
+        get_rental_agreement, get_rental_conditions, persist_event, update_rental_agreement,
+    },
+    history::EventType,
+    RentalConditionId, BILLION, SECONDS_PER_DAY,
+};
+use candid::Principal;
+use ic_cdk::println;
+
+/// The Swiss Subnet, whose rental agreement moves from App13CH to App7CH.
+/// Re-exported as `MIGRATION_TARGET_SUBNET` so the integration test drives the real
+/// principal rather than a copy that could drift from it.
+pub const TARGET_SUBNET: &str = "3zsyy-cnoqf-tvlun-ymf55-tkpca-ox7uw-kfxoh-7khwq-2gz43-wafem-lqe";
+
+/// Moves `TARGET_SUBNET`'s rental agreement from App13CH to App7CH, repricing the
+/// cycles they have already paid for but not yet burned.
+///
+/// Idempotent through the condition id itself: only agreements still on App13CH are
+/// touched, so the second upgrade finds none.
+///
+/// This is not a payment. The unburned cycles the user already owns are repriced at the
+/// cheaper App7CH daily cost, which extends the paid period. Pricing starts at the
+/// migration time rather than scaling the old `paid_until_nanos`, because the elapsed part
+/// of the period was already burned at the old rate.
+pub fn app13ch_to_app7ch() {
+    let Ok(subnet_id) = Principal::from_text(TARGET_SUBNET) else {
+        println!("Migration to App7CH skipped: TARGET_SUBNET is not a valid principal");
+        return;
+    };
+
+    let Some(agreement) = get_rental_agreement(&subnet_id) else {
+        println!("Migration to App7CH skipped: no rental agreement for subnet {subnet_id}");
+        return;
+    };
+
+    if agreement.rental_condition_id != RentalConditionId::App13CH {
+        println!("Migration to App7CH already applied or not applicable; nothing to do");
+        return;
+    }
+
+    let Some(new_conditions) = get_rental_conditions(RentalConditionId::App7CH) else {
+        println!("Migration to App7CH skipped: App7CH rental conditions not found");
+        return;
+    };
+
+    let cycles_remaining = agreement
+        .total_cycles_created
+        .saturating_sub(agreement.total_cycles_burned);
+    let old_paid_until_nanos = agreement.paid_until_nanos;
+
+    let now_nanos = ic_cdk::api::time();
+    let new_paid_until_nanos = reprice(
+        cycles_remaining,
+        new_conditions.daily_cost_cycles,
+        now_nanos,
+    );
+
+    if let Err(e) = update_rental_agreement(subnet_id, |mut agreement| {
+        agreement.rental_condition_id = RentalConditionId::App7CH;
+        agreement.paid_until_nanos = new_paid_until_nanos;
+        agreement
+    }) {
+        println!("Migration of subnet {subnet_id} to App7CH failed: {e}");
+        return;
+    }
+
+    persist_event(
+        EventType::RentalConditionSwitched {
+            subnet_id,
+            user: agreement.user,
+            old_condition_id: RentalConditionId::App13CH,
+            new_condition_id: RentalConditionId::App7CH,
+            cycles_remaining,
+            old_paid_until_nanos,
+            new_paid_until_nanos,
+        },
+        Some(subnet_id),
+    );
+    println!(
+        "Migrated subnet {subnet_id} from App13CH to App7CH: {cycles_remaining} cycles now \
+        paid until {new_paid_until_nanos} (was {old_paid_until_nanos})"
+    );
+}
+
+/// How long `cycles_remaining` lasts at `daily_cost_cycles`, as a deadline from `now_nanos`.
+///
+/// Truncating to a per-second cost makes a day cost marginally less than
+/// `daily_cost_cycles`, so the deadline is fractionally generous. Same rounding as the
+/// top-up path.
+fn reprice(cycles_remaining: u128, daily_cost_cycles: u128, now_nanos: u64) -> u64 {
+    let cost_cycles_per_second = daily_cost_cycles / (SECONDS_PER_DAY as u128);
+    if cost_cycles_per_second == 0 {
+        return u64::MAX;
+    }
+    let seconds_covered = cycles_remaining / cost_cycles_per_second;
+    (seconds_covered.saturating_mul(BILLION as u128))
+        .try_into()
+        .map_or(u64::MAX, |nanos: u64| now_nanos.saturating_add(nanos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TRILLION;
+
+    const APP13CH_DAILY: u128 = 820 * TRILLION;
+    const APP7CH_DAILY: u128 = 440 * TRILLION;
+    const DAY_NANOS: u64 = SECONDS_PER_DAY * BILLION;
+
+    #[test]
+    fn reprice_is_exact_for_whole_days() {
+        assert_eq!(reprice(10 * APP7CH_DAILY, APP7CH_DAILY, 0), 10 * DAY_NANOS);
+    }
+
+    #[test]
+    fn reprice_offsets_from_now() {
+        let now = 12_345 * DAY_NANOS;
+        let cycles = 10 * APP7CH_DAILY;
+        assert_eq!(reprice(cycles, APP7CH_DAILY, now), now + 10 * DAY_NANOS);
+    }
+
+    #[test]
+    fn cheaper_condition_buys_more_time() {
+        // 180 * 820 / 440 = 335.45
+        let days = reprice(180 * APP13CH_DAILY, APP7CH_DAILY, 0) / DAY_NANOS;
+        assert_eq!(days, 335);
+    }
+
+    #[test]
+    fn reprice_credits_only_whole_seconds() {
+        let cost_per_second = APP7CH_DAILY / (SECONDS_PER_DAY as u128);
+        // A truncated per-second cost undercharges the day, so just under a day's
+        // worth still covers the full day.
+        assert!(cost_per_second * (SECONDS_PER_DAY as u128) < APP7CH_DAILY);
+        assert_eq!(reprice(APP7CH_DAILY - 1, APP7CH_DAILY, 0), DAY_NANOS);
+
+        let cycles = cost_per_second * (SECONDS_PER_DAY as u128 - 1);
+        assert_eq!(reprice(cycles, APP7CH_DAILY, 0), DAY_NANOS - BILLION);
+
+        let cycles = APP7CH_DAILY + APP7CH_DAILY / 2;
+        assert_eq!(reprice(cycles, APP7CH_DAILY, 0) / DAY_NANOS, 1);
+    }
+
+    #[test]
+    fn no_cycles_left_means_no_time_left() {
+        let now = 99 * DAY_NANOS;
+        assert_eq!(reprice(0, APP7CH_DAILY, 0), 0);
+        assert_eq!(reprice(0, APP7CH_DAILY, now), now);
+    }
+
+    #[test]
+    fn reprice_saturates_instead_of_overflowing() {
+        assert_eq!(reprice(u128::MAX, APP7CH_DAILY, 0), u64::MAX);
+        assert_eq!(reprice(10 * APP7CH_DAILY, APP7CH_DAILY, u64::MAX), u64::MAX);
+        // A daily cost below one cycle per second would divide by zero.
+        assert_eq!(reprice(APP7CH_DAILY, 1, 0), u64::MAX);
+    }
+}

--- a/src/subnet_rental_canister/src/migration.rs
+++ b/src/subnet_rental_canister/src/migration.rs
@@ -32,8 +32,6 @@ use candid::Principal;
 use ic_cdk::println;
 
 /// The Swiss Subnet, whose rental agreement moves from App13CH to App7CH.
-/// Re-exported as `MIGRATION_TARGET_SUBNET` so the integration test drives the real
-/// principal rather than a copy that could drift from it.
 pub const TARGET_SUBNET: &str = "3zsyy-cnoqf-tvlun-ymf55-tkpca-ox7uw-kfxoh-7khwq-2gz43-wafem-lqe";
 
 /// Moves `TARGET_SUBNET`'s rental agreement from App13CH to App7CH, repricing the
@@ -42,10 +40,9 @@ pub const TARGET_SUBNET: &str = "3zsyy-cnoqf-tvlun-ymf55-tkpca-ox7uw-kfxoh-7khwq
 /// Idempotent through the condition id itself: only agreements still on App13CH are
 /// touched, so the second upgrade finds none.
 ///
-/// This is not a payment. The unburned cycles the user already owns are repriced at the
-/// cheaper App7CH daily cost, which extends the paid period. Pricing starts at the
-/// migration time rather than scaling the old `paid_until_nanos`, because the elapsed part
-/// of the period was already burned at the old rate.
+/// No payment is involved: the unburned cycles just buy more days at App7CH's cheaper rate.
+/// The new deadline is `now + remaining_cycles / new_daily_cost` rather than a scaling of the
+/// old one, because cycles burned before the migration were already charged at the old rate.
 pub fn app13ch_to_app7ch() {
     let Ok(subnet_id) = Principal::from_text(TARGET_SUBNET) else {
         println!("Migration to App7CH skipped: TARGET_SUBNET is not a valid principal");
@@ -90,7 +87,6 @@ pub fn app13ch_to_app7ch() {
 
     persist_event(
         EventType::RentalConditionSwitched {
-            subnet_id,
             user: agreement.user,
             old_condition_id: RentalConditionId::App13CH,
             new_condition_id: RentalConditionId::App7CH,

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -29,7 +29,7 @@ use subnet_rental_canister::{
     CreateRentalAgreementPayload, EmptyRecord, EventPage, ExecuteProposalError, OperationType,
     RentalAgreement, RentalAgreementStatus, RentalConditionId, RentalConditions, RentalRequest,
     SubnetRentalProposalPayload, TopUpSummary, UpdateSubnetAdminsError, UpdateSubnetAdminsPayload,
-    UpdateSubnetAdminsResult, E8S, TRILLION,
+    UpdateSubnetAdminsResult, E8S, MIGRATION_TARGET_SUBNET, TRILLION,
 };
 
 const SRC_WASM: &str = "../../subnet_rental_canister.wasm.gz";
@@ -161,8 +161,11 @@ fn get_todays_price(pic: &PocketIc) -> Tokens {
         "list_rental_conditions",
         encode_one(()).unwrap(),
     );
-    assert_eq!(res.len(), 1);
-    let (rental_condition_id, _rental_conditions) = res.first().unwrap();
+    let rental_condition_id = res
+        .iter()
+        .map(|(id, _)| *id)
+        .find(|id| *id == RentalConditionId::App13CH)
+        .expect("App13CH condition missing");
     // user finds current price by consulting SRC
     update::<Result<Tokens, String>>(pic, SRC_ID, None, "get_todays_price", rental_condition_id)
         .unwrap()
@@ -324,8 +327,16 @@ fn test_initial_proposal() {
         "get_history_page",
         (user_principal, None::<Option<u64>>),
     );
-    // 1 RentalConditionsChanged
-    assert_eq!(src_history.events.len(), 1);
+    // 1 RentalConditionsChanged per rental condition
+    let condition_count = query::<Vec<(RentalConditionId, RentalConditions)>>(
+        &pic,
+        SRC_ID,
+        None,
+        "list_rental_conditions",
+        (),
+    )
+    .len();
+    assert_eq!(src_history.events.len(), condition_count);
     // 1 RentalRequestCreated + 1 TransferSuccess (initial 10% lock)
     assert_eq!(user_history.events.len(), 2);
 
@@ -545,7 +556,12 @@ fn test_create_rental_agreement() {
         "list_rental_conditions",
         encode_one(()).unwrap(),
     );
-    let rental_condition = rental_conditions.first().unwrap().1.clone();
+    let rental_condition = rental_conditions
+        .iter()
+        .find(|(id, _)| *id == RentalConditionId::App13CH)
+        .expect("App13CH condition missing")
+        .1
+        .clone();
 
     // check total cycles created
     let remaining_icp_to_be_converted = final_subnet_price.e8s()
@@ -1302,8 +1318,117 @@ fn test_top_up_estimate_round_trip_consistency() {
     );
 }
 
+/// Rents the migration's real target principal so the test cannot drift from it. A rental
+/// agreement's subnet id is only ever data (it is forwarded to the CMC, never called), so
+/// it does not need to be a subnet PocketIC actually hosts.
+#[test]
+fn upgrade_migrates_target_subnet_to_app7ch() {
+    let pic = setup_with_rented_subnet();
+    let subnet_id = Principal::from_text(MIGRATION_TARGET_SUBNET).unwrap();
+    rent_subnet_helper(&pic, subnet_id, USER_1);
+
+    let before = get_rental_agreement(&pic, subnet_id);
+    assert_eq!(before.rental_condition_id, RentalConditionId::App13CH);
+
+    // Burn some cycles so the migration reprices a partially consumed agreement rather
+    // than the full initial amount.
+    pic.advance_time(Duration::from_secs(30 * SECONDS_PER_DAY));
+    for _ in 0..5 {
+        pic.tick();
+    }
+    let burned = get_rental_agreement(&pic, subnet_id);
+    assert!(burned.total_cycles_burned > 0);
+    let events_before = subnet_event_count(&pic, subnet_id);
+
+    let src_wasm = fs::read(SRC_WASM).expect("Build the wasm with ./scripts/build.sh");
+    pic.upgrade_canister(SRC_ID, src_wasm.clone(), encode_one(()).unwrap(), None)
+        .unwrap();
+
+    let after = get_rental_agreement(&pic, subnet_id);
+    assert_eq!(after.rental_condition_id, RentalConditionId::App7CH);
+
+    // The remaining cycles are unchanged; only their price per day is.
+    let cycles_remaining = burned.total_cycles_created - burned.total_cycles_burned;
+    assert_eq!(after.total_cycles_created, burned.total_cycles_created);
+    assert_eq!(after.total_cycles_burned, burned.total_cycles_burned);
+
+    // Repricing runs from the upgrade time, not from the old deadline.
+    let app7ch_daily = get_rental_condition(&pic, RentalConditionId::App7CH).daily_cost_cycles;
+    let now_nanos = pic.get_time().as_nanos_since_unix_epoch();
+    let expected_seconds = cycles_remaining / (app7ch_daily / SECONDS_PER_DAY as u128);
+    assert_eq!(
+        after.paid_until_nanos,
+        now_nanos + (expected_seconds as u64 * NANOS_PER_SECOND)
+    );
+    // The cheaper condition must buy more time than was left before.
+    assert!(after.paid_until_nanos > burned.paid_until_nanos);
+
+    // The switch is recorded against the subnet. EventType is private to the crate, so
+    // the count is all the test can assert on.
+    assert_eq!(subnet_event_count(&pic, subnet_id), events_before + 1);
+
+    // A second upgrade must not reprice again, nor record a second switch.
+    pic.upgrade_canister(SRC_ID, src_wasm, encode_one(()).unwrap(), None)
+        .unwrap();
+    let after_second = get_rental_agreement(&pic, subnet_id);
+    assert_eq!(after_second.rental_condition_id, RentalConditionId::App7CH);
+    assert_eq!(after_second.paid_until_nanos, after.paid_until_nanos);
+    assert_eq!(subnet_event_count(&pic, subnet_id), events_before + 1);
+}
+
+/// PocketIC never assigns the migration's hardcoded mainnet subnet id.
+#[test]
+fn upgrade_does_not_migrate_unrelated_agreements() {
+    let pic = setup_with_rented_subnet();
+    let subnet_id = *pic.topology().get_app_subnets().first().unwrap();
+    rent_subnet_helper(&pic, subnet_id, USER_1);
+
+    let before = get_rental_agreement(&pic, subnet_id);
+    assert_eq!(before.rental_condition_id, RentalConditionId::App13CH);
+
+    let src_wasm = fs::read(SRC_WASM).expect("Build the wasm with ./scripts/build.sh");
+    pic.upgrade_canister(SRC_ID, src_wasm, encode_one(()).unwrap(), None)
+        .unwrap();
+
+    let after = get_rental_agreement(&pic, subnet_id);
+    assert_eq!(after, before);
+}
+
 // ====================================================================================================================
 // Helpers
+fn subnet_event_count(pic: &PocketIc, subnet_id: Principal) -> usize {
+    query_multi_arg::<EventPage>(
+        pic,
+        SRC_ID,
+        None,
+        "get_history_page",
+        (subnet_id, None::<Option<u64>>),
+    )
+    .events
+    .len()
+}
+
+fn get_rental_condition(pic: &PocketIc, id: RentalConditionId) -> RentalConditions {
+    query::<Vec<(RentalConditionId, RentalConditions)>>(
+        pic,
+        SRC_ID,
+        None,
+        "list_rental_conditions",
+        (),
+    )
+    .into_iter()
+    .find(|(k, _)| *k == id)
+    .expect("Rental condition not found")
+    .1
+}
+
+fn get_rental_agreement(pic: &PocketIc, subnet_id: Principal) -> RentalAgreement {
+    query::<Vec<RentalAgreement>>(pic, SRC_ID, None, "list_rental_agreements", ())
+        .into_iter()
+        .find(|a| a.subnet_id == subnet_id)
+        .expect("Rental agreement not found")
+}
+
 fn query<T: for<'a> Deserialize<'a> + candid::CandidType>(
     pic: &PocketIc,
     canister_id: Principal,

--- a/src/subnet_rental_canister/tests/integration_tests.rs
+++ b/src/subnet_rental_canister/tests/integration_tests.rs
@@ -1318,9 +1318,6 @@ fn test_top_up_estimate_round_trip_consistency() {
     );
 }
 
-/// Rents the migration's real target principal so the test cannot drift from it. A rental
-/// agreement's subnet id is only ever data (it is forwarded to the CMC, never called), so
-/// it does not need to be a subnet PocketIC actually hosts.
 #[test]
 fn upgrade_migrates_target_subnet_to_app7ch() {
     let pic = setup_with_rented_subnet();


### PR DESCRIPTION
Introduces App7CH (440 T cycles/day, 180-day initial period) alongside App13CH, and a one-shot post_upgrade migration that moves the Swiss Subnet's rental agreement onto it.

The migration reprices the cycles the renter has already paid for but not yet burned at the cheaper daily cost, extending the paid period. It is not a payment: no cycles are created or destroyed. Pricing runs from the migration time rather than scaling the old paid_until_nanos, because the elapsed part of the period was already burned at the old rate.